### PR TITLE
Handle extra whitespace in W3C extended logs, including in between comment lines and in Fields: line.

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -248,7 +248,10 @@ class W3cExtendedFormat(RegexFormat):
         # if we're reading from stdin, we can't seek, so don't read any more than the Fields line
         header_lines = []
         while fields_line is None:
-            line = file.readline()
+            line = file.readline().strip()
+
+            if not line:
+                continue
 
             if not line.startswith('#'):
                 break
@@ -282,14 +285,17 @@ class W3cExtendedFormat(RegexFormat):
             expected_fields[field_name] = field_regex
 
         # Skip the 'Fields: ' prefix.
-        fields_line = fields_line[9:]
-        for field in fields_line.split():
+        fields_line = fields_line[9:].strip()
+        for field in re.split('\s+', fields_line):
             try:
                 regex = expected_fields[field]
             except KeyError:
                 regex = '\S+'
             full_regex.append(regex)
         full_regex = '\s+'.join(full_regex)
+
+        logging.debug("Based on 'Fields:' line, computed regex to be %s", full_regex)
+
         self.regex = re.compile(full_regex)
 
     def check_for_iis_option(self):

--- a/tests/logs/iis_custom.log
+++ b/tests/logs/iis_custom.log
@@ -1,7 +1,10 @@
 #Software: IIS Advanced Logging Module
+
 #Version: 1.0
+    
 #Start-Date: 2014-11-18 00:00:00.128
-#Fields:  date-local time-local s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) cs(Host) sc-status sc-substatus sc-win32-status TimeTakenMS
+   
+#Fields:   date-local time-local   s-ip   cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) cs(Host) sc-status sc-substatus sc-win32-status TimeTakenMS
 2012-08-15 17:00:00.363 10.10.28.140 GET /Products/theProduct - 80 - "70.95.0.0" "Mozilla/5.0 (Linux; Android 4.4.4; SM-G900V Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36" "http://example.com/Search/SearchResults.pg?informationRecipient.languageCode.c=en" "xzy.example.com" 200 0 0 109
 2012-08-15 17:00:00.660 10.10.28.140 GET /Topic/hw43061 - 80 - "70.95.32.0" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2227.1 Safari/537.36" - "example.hello.com" 301 0 0 0
 2012-08-15 17:00:00.675 10.10.28.140 GET /hello/world/6,681965 - 80 - "173.5.0.0" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 Safari/537.36" - "hello.example.com" 404 0 0 359

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -410,7 +410,7 @@ def test_iis_custom_format():
     assert hits[0]['filename'] == 'logs/iis_custom.log'
     assert hits[0]['is_redirect'] == False
     assert hits[0]['date'] == datetime.datetime(2012, 8, 15, 17, 0)
-    assert hits[0]['lineno'] == 4
+    assert hits[0]['lineno'] == 7
     assert hits[0]['ip'] == u'70.95.0.0'
     assert hits[0]['query_string'] == ''
     assert hits[0]['path'] == u'/Products/theProduct'
@@ -429,7 +429,7 @@ def test_iis_custom_format():
     assert hits[1]['filename'] == 'logs/iis_custom.log'
     assert hits[1]['is_redirect'] == True
     assert hits[1]['date'] == datetime.datetime(2012, 8, 15, 17, 0)
-    assert hits[1]['lineno'] == 5
+    assert hits[1]['lineno'] == 8
     assert hits[1]['ip'] == '70.95.32.0'
     assert hits[1]['query_string'] == ''
     assert hits[1]['path'] == u'/Topic/hw43061'
@@ -448,7 +448,7 @@ def test_iis_custom_format():
     assert hits[2]['filename'] == 'logs/iis_custom.log'
     assert hits[2]['is_redirect'] == False
     assert hits[2]['date'] == datetime.datetime(2012, 8, 15, 17, 0)
-    assert hits[2]['lineno'] == 6
+    assert hits[2]['lineno'] == 9
     assert hits[2]['ip'] == u'173.5.0.0'
     assert hits[2]['query_string'] == ''
     assert hits[2]['path'] == u'/hello/world/6,681965'


### PR DESCRIPTION
As title.