### PR TITLE
Add option for date format in logs.

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -563,8 +563,12 @@ class Configuration(object):
                  "Overrides --log-format-name." % (', '.join(available_regex_groups))
         )
         option_parser.add_option(
+            '--log-date-format', dest='log_date_format', default=None,
+            help="Format string used to parse dates."
+        )
+        option_parser.add_option(
             '--log-hostname', dest='log_hostname', default=None,
-            help="Force this hostname for a log format that doesn't incldude it. All hits "
+            help="Force this hostname for a log format that doesn't include it. All hits "
             "will seem to came to this host"
         )
         option_parser.add_option(
@@ -760,7 +764,7 @@ class Configuration(object):
             logging.debug('Accepted hostnames: all')
 
         if self.options.log_format_regex:
-            self.format = RegexFormat('custom', self.options.log_format_regex)
+            self.format = RegexFormat('custom', self.options.log_format_regex, self.options.log_date_format)
         elif self.options.log_format_name:
             try:
                 self.format = FORMATS[self.options.log_format_name]


### PR DESCRIPTION
Custom log format can be specified with --log-format-regex option.
But there's no way to also specify a format string for the date.