### PR TITLE
Fix getSitesIdFromSiteUrl API call

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1314,9 +1314,13 @@ class DynamicResolver(object):
             self._cache['sites'] = piwik.call_api('SitesManager.getAllSites')
 
     def _get_site_id_from_hit_host(self, hit):
+        if re.match('^https?://', hit.host):
+            host_url=hit.host
+        else:
+            host_url='http://' + hit.host
         return piwik.call_api(
             'SitesManager.getSitesIdFromSiteUrl',
-            url='http://' + hit.host,
+            url=host_url
         )
 
     def _add_site(self, hit):

--- a/import_logs.py
+++ b/import_logs.py
@@ -1316,7 +1316,7 @@ class DynamicResolver(object):
     def _get_site_id_from_hit_host(self, hit):
         return piwik.call_api(
             'SitesManager.getSitesIdFromSiteUrl',
-            url=hit.host,
+            url='http://' + hit.host,
         )
 
     def _add_site(self, hit):


### PR DESCRIPTION
Call uses hit without protocol and this search will always fail and
create a new site every time this script is called

This bug is reported as #80 