### PR TITLE
Use bulk tracking indices to display the lines of logs that were considered invalid by the Piwik tracker.

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1700,6 +1700,8 @@ class Recorder(object):
                     # debug tracker output will always break the normal JSON output.
                     if not config.options.debug_tracker:
                         logging.info("tracker response:\n%s" % response)
+
+                    response = {}
                 
                 if ('invalid_indices' in response and isinstance(response['invalid_indices'], list) and
                     response['invalid_indices']):


### PR DESCRIPTION
As title.

Tests are included w/ https://github.com/piwik/piwik/pull/8644.