### PR TITLE
Add OVH log format

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -397,7 +397,8 @@ class AmazonCloudFrontFormat(W3cExtendedFormat):
         else:
             return super(AmazonCloudFrontFormat, self).get(key)
 
-_HOST_PREFIX = '(?P<host>[\w\-\.]*)(?::\d+)?\s+'
+_HOST_PREFIX = '(?P<host>([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,})(?::\d+)?\s+'
+
 _COMMON_LOG_FORMAT = (
     '(?P<ip>\S+)\s+\S+\s+(?P<userid>\S+)\s+\[(?P<date>.*?)\s+(?P<timezone>.*?)\]\s+'
     '"\S+\s+(?P<path>.*?)\s+\S+"\s+(?P<status>\S+)\s+(?P<length>\S+)'
@@ -419,6 +420,12 @@ _ELB_LOG_FORMAT = (
     '"\S+\s+\w+:\/\/(?P<host>[\w\-\.]*):\d+(?P<path>\/\S*)\s+[^"]+"\s+"(?P<user_agent>[^"]+)"\s+\S+\s+\S+'
 )
 
+_OVH_FORMAT = (
+    '(?P<ip>\S+)\s+' + _HOST_PREFIX + '(?P<userid>\S+)\s+\[(?P<date>.*?)\s+(?P<timezone>.*?)\]\s+'
+    '"\S+\s+(?P<path>.*?)\s+\S+"\s+(?P<status>\S+)\s+(?P<length>\S+)'
+    '\s+"(?P<referrer>.*?)"\s+"(?P<user_agent>.*?)"'
+)
+
 FORMATS = {
     'common': RegexFormat('common', _COMMON_LOG_FORMAT),
     'common_vhost': RegexFormat('common_vhost', _HOST_PREFIX + _COMMON_LOG_FORMAT),
@@ -432,6 +439,7 @@ FORMATS = {
     'icecast2': RegexFormat('icecast2', _ICECAST2_LOG_FORMAT),
     'elb': RegexFormat('elb', _ELB_LOG_FORMAT, '%Y-%m-%dT%H:%M:%S'),
     'nginx_json': JsonFormat('nginx_json'),
+    'ovh': RegexFormat('ovh', _OVH_FORMAT)
 }
 
 ##

--- a/tests/logs/ovh.log
+++ b/tests/logs/ovh.log
@@ -1,0 +1,1 @@
+1.2.3.4 www.example.com theuser [10/Feb/2012:16:42:07 -0500] "GET / HTTP/1.1" 301 368 "-" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.56 Safari/535.11"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -387,6 +387,9 @@ def check_match_groups(format_name, groups):
     check_function = symbols['check_' + format_name + '_groups']
     return check_function(groups)
 
+def check_ovh_groups(groups):
+    check_common_complete_groups(groups)
+
 # parsing tests
 def test_format_parsing():
     # test format regex parses correctly


### PR DESCRIPTION
OVH shared hosting are providing raw logs in a format which is a bit different from the common_vhost format. Actually, the host is not before, but after the IP address.

So I added a regex for this specific case, for my own needs. If you think it's interesting, just feel free to merge it...

And thank you for your contribution to libre software!
