### PR TITLE
Issue when generation_time_milli is 0

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -151,7 +151,7 @@ class JsonFormat(BaseFormat):
     def get(self, key):
         # Some ugly patchs ...
         if key == 'generation_time_milli':
-            self.json[key] =  int(self.json[key] * 1000)
+            self.json[key] =  int(float(self.json[key]) * 1000)
         # Patch date format ISO 8601
         elif key == 'date':
             tz = self.json[key][19:]


### PR DESCRIPTION
Whenever generation_time_milli is 0 ( or more accurately, `0.0000`), the json returned will be interpreted as a *`string`* and not a *`float`*.

Forcing the cast fixes the issue.

Happened to me while serving static html pages.