### PR TITLE
Fixes #126

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1502,6 +1502,9 @@ class DynamicResolver(object):
             # We only consider requests with piwik.php which don't need host to be imported
             return self._resolve_when_replay_tracking(hit)
         else:
+            # Workaround for empty Host bug issue #126
+            if hit.host.strip() == '':
+                hit.host = 'nohost'
             return self._resolve_by_host(hit)
 
     def check_format(self, format):


### PR DESCRIPTION
fast, probably ugly workaround fix for #126 due to Host regex can't be empty or logimport hangs in a loop forever.

a better long term solution would be to trigger invalidate/ignore empty host lines and throw an invalid log line exception and just ignore those lines probably, but due to lack of python knowledge, i can't implement such case.
