### PR TITLE
Support for custom bots

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -597,6 +597,10 @@ class Configuration(object):
             help="Track bots. All bot visits will have a Custom Variable set with name='Bot' and value='$Bot_user_agent_here$'"
         )
         option_parser.add_option(
+            '--custom-bot', dest='custom_bots', action='append', default=[],
+            help="Define user agents (or parts thereof) to be treated as Bots. Requires --enable-bots to be active. Can be specified multiple times"
+        )
+        option_parser.add_option(
             '--enable-http-errors', dest='enable_http_errors',
             action='store_true', default=False,
             help="Track HTTP errors (status code 4xx or 5xx)"
@@ -1932,7 +1936,7 @@ class Parser(object):
 
     def check_user_agent(self, hit):
         user_agent = hit.user_agent.lower()
-        for s in itertools.chain(EXCLUDED_USER_AGENTS, config.options.excluded_useragents):
+        for s in itertools.chain(EXCLUDED_USER_AGENTS + tuple(config.options.custom_bots), config.options.excluded_useragents):
             if s in user_agent:
                 if config.options.enable_bots:
                     hit.is_robot = True


### PR DESCRIPTION
Because some sites have different, local bots this change allows those bots to
be passed in via options to the script rather than needing to modify the script
directly.

example usage:

```
python /srv/piwik-log-analytics/import_logs.py --url=https://example.piwik.pro/ --idsite=5 --enable-bots /var/log/nginx/*-access.log --custom-bot='_bot_' --custom-bot='Discourse.org'
```

This should suppress messages from Pingdom (which use Pingdom_bot_version) and
Discourse Server Monitoring.

This change is intended to compliment http://piwik.org/faq/how-to/faq_17483/
