### PR TITLE
Add pingdom to EXCLUDED_USER_AGENTS list

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -97,6 +97,7 @@ EXCLUDED_USER_AGENTS = (
     'voilabot',
     'yahoo',
     'yandex',
+    'Pingdom.com_bot_',
 )
 
 PIWIK_DEFAULT_MAX_ATTEMPTS = 3


### PR DESCRIPTION
Since pingdom is a popular service I thought it might be worth having on the
bot list. I won't be offended if the suggestion is to use _bot_ instead as it
would handle a wider variety of services.
