### PR TITLE
Fix Pingdom bot exclusion

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -97,7 +97,7 @@ EXCLUDED_USER_AGENTS = (
     'voilabot',
     'yahoo',
     'yandex',
-    'Pingdom.com_bot_',
+    'pingdom.com_bot_',
 )
 
 PIWIK_DEFAULT_MAX_ATTEMPTS = 3


### PR DESCRIPTION
UA from logs are transformed into lowercase before comparison to
excluded UA. Therefore excluded UA must be in lowercase.

Signed-off-by: Kevin Decherf <kevin@kdecherf.com>