### PR TITLE
Prevent NameError during configuration phase

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -1407,15 +1407,22 @@ class Piwik(object):
                 if hasattr(e, 'read'):
                     message = message + ", response: " + e.read()
 
+                try:
+                    delay_after_failure = config.options.delay_after_failure
+                    max_attempts = config.options.max_attempts
+                except NameError:
+                    delay_after_failure = PIWIK_DEFAULT_DELAY_AFTER_FAILURE
+                    max_attempts = PIWIK_DEFAULT_MAX_ATTEMPTS
+
                 errors += 1
-                if errors == config.options.max_attempts:
+                if errors == max_attempts:
                     logging.info("Max number of attempts reached, server is unreachable!")
 
                     raise Piwik.Error(message, code)
                 else:
                     logging.info("Retrying request, attempt number %d" % (errors + 1))
 
-                    time.sleep(config.options.delay_after_failure)
+                    time.sleep(delay_after_failure)
 
     @classmethod
     def call(cls, path, args, expected_content=None, headers=None, data=None, on_failure=None):


### PR DESCRIPTION
As it just popped up in piwik/piwik#11943 the log importer throws a potentially misleading stacktrace at you if the token authentication cannot be fetched when using login/password.

This happens because the calls to the API require the config object for retry handling. But if the call is made to fetch the authentication token this object is not yet available. So if the call fails for whatever reason the script aborts with a `NameError`.

The real error is still at the very top of the output but some people might look at only the last line (`NameError: global name 'config' is not defined`) and miss the real error.

With this patch the fallback is made to the default values for retry count and delay.