### PR TITLE
Only issue an invalid line status, when the line was really invalid and skipped

### DIFF
--- a/import_logs.py
+++ b/import_logs.py
@@ -2338,7 +2338,6 @@ class Parser(object):
                     try:
                         hit.generation_time_milli = float(format.get('generation_time_secs')) * 1000
                     except (ValueError, BaseFormatException):
-                        invalid_line(line, 'invalid generation time')
                         hit.generation_time_milli = 0
 
             if config.options.log_hostname:


### PR DESCRIPTION
Currently the invalid line is reported even for lines that are still imported.

Here is an example of the issue. The log file has 590887 lines, and 584895 were imported successfully. But the output also reports  594622 lines which is not true.

```
Logs import summary
-------------------

    584895 requests imported successfully
    0 requests were downloads
    596860 requests ignored:
        0 HTTP errors
        0 HTTP redirects
        594622 invalid log lines
        2147 filtered log lines
        0 requests did not match any known site
        0 requests did not match any --hostname
        91 requests done by bots, search engines...
        0 requests to static resources (css, js, images, ico, ttf...)
        0 requests to file downloads did not match any --download-extensions

Website import summary
----------------------

    584895 requests imported to 1 sites
        1 sites already existed
        0 sites were created:

    0 distinct hostnames did not match any existing site:

Performance summary
-------------------

    Total time: 1676 seconds
    Requests imported per second: 348.82 requests per second

```